### PR TITLE
add very tiny features of joining paths to data dirs && add script to check identity of efs <--> mseed or SAC

### DIFF
--- a/Python/P0_download_miniSEED_example_CI.py
+++ b/Python/P0_download_miniSEED_example_CI.py
@@ -8,6 +8,7 @@ import obspy
 from obspy.clients.fdsn.mass_downloader import CircularDomain, \
     Restrictions, MassDownloader
 from obspy.clients.fdsn import Client
+import os
 
 # define search domain
 domain = CircularDomain(latitude=35.77, longitude=-117.599,
@@ -29,9 +30,15 @@ restrictions = Restrictions(
 # instantiate mass downloader
 mdl = MassDownloader()
 
+# prepare storages
+mseed_storage = '../EX_DATA/CI/waveforms'
+stationxml_storage = '../EX_DATA/CI/stations'
+os.makedirs(mseed_storage, exist_ok=True)
+os.makedirs(stationxml_storage, exist_ok=True)
+
 # download data
 print("Downloading data, please wait...")
 print("(Note, no changes will be made if data does not need to be updated).")
-mdl.download(domain,restrictions, mseed_storage="../EX_DATA/CI/waveforms/",
-             stationxml_storage="../EX_DATA/CI/stations/")
+mdl.download(domain,restrictions, mseed_storage=mseed_storage,
+             stationxml_storage=stationxml_storage)
 print("\nDONE")

--- a/Python/P1_miniSEED2EFS_example.py
+++ b/Python/P1_miniSEED2EFS_example.py
@@ -1,5 +1,5 @@
 ### Example script to interact with EFS files using ObsPy.
-#   Here we gather event, station, and waveform data in ObsPy format for the 
+#   Here we gather event, station, and waveform data in ObsPy format for the
 #   2019 Ridgecrest earthquake. We then create an EFS file from this information,
 #   and test file export and conversion.
 
@@ -14,8 +14,8 @@ from obspy.clients.fdsn import Client
 import os
 
 # Specify file paths
-EFSPATH = "./"
-miniSEED_PATH = './CI/'
+EFSPATH = "../EX_DATA"
+miniSEED_PATH = '../EX_DATA/CI'
 
 # Download event information for Ridgecrest using ObsPy
 print("\nDownloading Ridgecrest event information...")
@@ -26,11 +26,11 @@ cat = client.get_events(starttime = origin_time - 20, endtime = origin_time + 20
 print("Done\n")
 
 # Read waveforms into obspy Stream and Inventory
-iPATH = miniSEED_PATH + 'waveforms/'
-iPATH_inv = miniSEED_PATH + 'stations/'
+iPATH = os.path.join(miniSEED_PATH, 'waveforms')
+iPATH_inv = os.path.join(miniSEED_PATH, 'stations')
 try:
-    st1 = obspy.read(iPATH + '*')
-    inv1 = obspy.read_inventory(iPATH_inv + '*')
+    st1 = obspy.read(os.path.join(iPATH, '*'))
+    inv1 = obspy.read_inventory(os.path.join(iPATH_inv, '*'))
     print("Reading data from:", iPATH)
     print(st1)
     print("First trace:")
@@ -60,8 +60,8 @@ export_efs(EFSPATH, filename2, efs_data,np.int32,"i")
 print("Done.")
 
 # Read EFS with customized precision as they were stored
-efs_data_2 = EFS(EFSPATH + filename,np.float32,np.int32)
-efs_data_3 = EFS(EFSPATH + filename2,np.int32,np.int32)
+efs_data_2 = EFS(os.path.join(EFSPATH, filename),np.float32,np.int32)
+efs_data_3 = EFS(os.path.join(EFSPATH, filename2),np.int32,np.int32)
 # Convert EFS to obspy
 print("\nConverting EFS object back to a stream.")
 st2 = efs_data_2.to_obspy()

--- a/Python/checktraces.py
+++ b/Python/checktraces.py
@@ -1,0 +1,54 @@
+'''
+A Python script to check if the data conversion (original <--> EFS) is OK
+usage: (do not forget quotation marks!)
+python checktraces.py '../EX_DATA/EFS_Example.efs' '../EX_DATA/CI/waveforms/*'
+'''
+
+import os
+import sys
+import numpy as np
+import obspy
+from EFSpy_module import EFS
+import matplotlib.pyplot as plt
+
+def main():
+
+    # pass arguments
+    args = sys.argv
+    efsname = args[1]
+    original = args[2]
+
+    # load EFS file
+    efs_data = EFS(efsname)
+
+    # load original original files
+    st = obspy.read(original)
+
+    # randomly select one station to check identity
+    j = np.random.randint(0,len(st)) # random station ID
+    originalTrace = st[j].copy()
+    wf = efs_data.waveforms[j]
+
+    # display station code, location, and channel
+    print('EFS     :', efs_data.waveforms[j]['stname'].strip(), efs_data.waveforms[j]['loccode'].strip(), efs_data.waveforms[j]['chnm'].strip())
+    print('original:', st[j].stats.station, st[j].stats.location, st[j].stats.channel)
+
+    # judge if the two traces are identical
+    if (wf['data'] == originalTrace.data).all():
+        print('two traces are identical!')
+    else:
+        print('something wrong...')
+
+    # plot traces
+    fig, (ax1, ax2) = plt.subplots(2, 1)
+
+    ax1.plot(wf['data'], color='k', label='EFS: '+st[j].stats.station+' station')
+    ax1.plot(originalTrace.data, color='r', label='original: '+efs_data.waveforms[j]['stname'].strip()+' station')
+    ax1.legend()
+
+    ax2.plot(wf['data'] - originalTrace.data, color='C7', label='diff')
+    ax2.legend()
+    plt.show()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I added the very tiny features to `Python/P0_download_miniSEED_example_CI.py` and `Python/P1_miniSEED2EFS_example.py` to handle data directories: 

- In case the data directory does not exist before requesting data
```python
mseed_storage = '../EX_DATA/CI/waveforms'
stationxml_storage = '../EX_DATA/CI/stations'
os.makedirs(mseed_storage, exist_ok=True)
os.makedirs(stationxml_storage, exist_ok=True)
```

- Join paths to data directories in a slightly secure way (... I quite often forget to add slash "/" at the end of the path:innocent:)
```pytyhon
#iPATH = miniSEED_PATH + 'waveforms/'
iPATH = os.path.join(miniSEED_PATH, 'waveforms')
```

---
I also added a simple script `Python/checktraces.py` to check identity of the original and the converted EFS data. 

---
This  pull request is nothing important, so please feel free to ignore:relaxed: